### PR TITLE
Use exec in entrypoint scripts

### DIFF
--- a/pulp-api/entrypoint.sh
+++ b/pulp-api/entrypoint.sh
@@ -14,6 +14,6 @@ if [[ -n $PULP_ADMIN_PASSWORD ]]; then
 fi
 
 echo "[INFO] Starting API server"
-gunicorn pulpcore.app.wsgi:application \
-          --bind "0.0.0.0:${PULP_API_BIND_PORT}" \
-          --access-logfile -
+exec gunicorn pulpcore.app.wsgi:application \
+              --bind "0.0.0.0:${PULP_API_BIND_PORT}" \
+              --access-logfile -

--- a/pulp-content/entrypoint.sh
+++ b/pulp-content/entrypoint.sh
@@ -7,8 +7,8 @@ echo "[INFO] Collecting static files"
 django-admin collectstatic --noinput
 
 echo "[INFO] Starting content server"
-gunicorn pulpcore.content:server \
-          --bind "0.0.0.0:${PULP_CONTENT_BIND_PORT}" \
-          --worker-class 'aiohttp.GunicornWebWorker' \
-          -w ${PULP_CONTENT_WORKERS} \
-          --access-logfile -
+exec gunicorn pulpcore.content:server \
+              --bind "0.0.0.0:${PULP_CONTENT_BIND_PORT}" \
+              --worker-class 'aiohttp.GunicornWebWorker' \
+              -w ${PULP_CONTENT_WORKERS} \
+              --access-logfile -

--- a/pulp-resource-manager/entrypoint.sh
+++ b/pulp-resource-manager/entrypoint.sh
@@ -1,4 +1,8 @@
 #!/bin/bash -e
 
 REDIS_URL=${PULP_REDIS_URL:-"localhost:6379"}
-rq worker --url "$REDIS_URL" -n 'resource-manager' -w 'pulpcore.tasking.worker.PulpWorker' --disable-job-desc-logging
+exec rq worker \
+        --url "$REDIS_URL" \
+        -n 'resource-manager' \
+        -w 'pulpcore.tasking.worker.PulpWorker' \
+        --disable-job-desc-logging

--- a/pulp-worker/entrypoint.sh
+++ b/pulp-worker/entrypoint.sh
@@ -2,4 +2,8 @@
 
 REDIS_URL=${PULP_REDIS_URL:-"localhost:6379"}
 WORKER_NAME=${WORKER_NAME:-"worker@%h"}
-rq worker --url "$REDIS_URL" -n "$WORKER_NAME" -w 'pulpcore.tasking.worker.PulpWorker' --disable-job-desc-logging
+exec rq worker \
+        --url "$REDIS_URL" \
+        -n "$WORKER_NAME" \
+        -w 'pulpcore.tasking.worker.PulpWorker' \
+        --disable-job-desc-logging


### PR DESCRIPTION
Bash normally eats the TERM signal instead of propagating it through to child processes.  As a result, when docker/k8s tells a container to exit, the entrypoint (bash) gets a TERM, and just exits. Technically, tini gets the signal, which it propagates to bash, but either way...  When bash exits, the child process is orphaned and then taken back over by the parent (tini, in this case); Bash does not propagate the signal down.  Tini waits for the child to exit, which exceeds the timeout Docker/k8s/whatever has, at which point a KILL is sent.  This results in rq uncleanly exiting.  It also results in gunicorn uncleanly exiting, which is generally less of a problem.  The biggest issue is really with the resource-manager, since an unclean exit means a new instance can't start back up until the timeout for an unreponsive task manager has elapsed.

Installing a TERM trap in the entrypoiunt won't work, because Bash doesn't actually run the handler while it's waiting for a child process to exit.  Since it's waiting for a deamon which will never (well, never intentionally) exit, the same situation happens.

However, since nothing needs to run after rq/gunicorn, we can solve this whole problem by using an exec and taking Bash out of the picture altogether.  Both rq and gunicorn have SIG_TERM handlers, so they properly handle the signal and cleanly exit, allowing a new instance to start back up immediately and _hopefully_ resulting in less of a mess when tasks things get interrupted.